### PR TITLE
Implementation of is_playing and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![PyPI](https://img.shields.io/pypi/v/swspotify.svg)
 [![Downloads](https://pepy.tech/badge/swspotify)](https://pepy.tech/project/swspotify)
 
-SwSpotify is a python library to get the song and artist of the currently playing song from the Spotify application faster and without using the API. It works on Windows, Linux and macOS. 
+SwSpotify is a Python library to get the song and artist of the currently playing song from the Spotify application faster and without using the API. It works on Windows, Linux and macOS. 
 
 The original repository was [spotilib](https://github.com/XanderMJ/spotilib) which worked just for Windows and hasn't been updated since a long while when it broke on account of Spotify updating their application.
 
@@ -15,36 +15,43 @@ Originally made for use in [SwagLyrics for Spotify](https://github.com/SwagLyric
 ## Installation
 
 Requires Python3. Use pip or pip3 depending on your installation.
-```
+```shell
 pip install SwSpotify
 ```
 
 ## Usage
 
 Use it in your project by importing it as:
+
 ```pydocstring
 from SwSpotify import spotify
 ```
+
 Then you can access the song and artist as:
+
 ```pydocstring
 >>> spotify.song()
 'Hello'
 >>> spotify.artist()
 'Adele'
 ```
+
 Since mostly song and artist are used in conjunction, there is a `current()` method as well.
+
 ```pydocstring
 >>> spotify.current()
 ('Hello', 'Adele')
 ```
+
 This allows you to access song and artist by tuple unpacking as:
+
 ```pydocstring
 >>> song, artist = spotify.current()
 ```
 
 A `SpotifyNotRunning` Exception is raised if Spotify is closed or paused. `SpotifyClosed` and `SpotifyPaused` inherit from `SpotifyNotRunning`, meaning that you can catch both at the same time:
 
-```
+```python
 try:
     title, artist = spotify.current()
 except SpotifyNotRunning as e:

--- a/README.md
+++ b/README.md
@@ -31,26 +31,28 @@ Then you can access the song and artist as:
 'Hello'
 >>> spotify.artist()
 'Adele'
->>> spotify.is_playing()
-True
 ```
 Since mostly song and artist are used in conjunction, there is a `current()` method as well.
 ```pydocstring
 >>> spotify.current()
 ('Hello', 'Adele')
 ```
-or you can pass `return_status=True` to also get whether it's playing or not.
-```pydocstring
->>> spotify.current(return_status=True)
-('Hello', 'Adele', True)
-```
 This allows you to access song and artist by tuple unpacking as:
 ```pydocstring
 >>> song, artist = spotify.current()
->>> song, artist, is_playing = spotify.current(return_status=True)
 ```
 
-If Spotify is not running or is paused, a `SpotifyNotRunning` Exception is raised.
+A `SpotifyNotRunning` Exception is raised if Spotify is closed or paused. `SpotifyClosed` and `SpotifyPaused` inherit from `SpotifyNotRunning`, meaning that you can catch both at the same time:
+
+```
+try:
+    title, artist = spotify.current()
+except SpotifyNotRunning as e:
+    print(e)
+else:
+    print(f"{title} - {artist}")
+```
+
 ## Compiling SwSpotify for Development
 
 - Clone the repo by `git clone https://github.com/SwagLyrics/SwSpotify.git` or use ssh.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,23 @@ Then you can access the song and artist as:
 'Hello'
 >>> spotify.artist()
 'Adele'
+>>> spotify.is_playing()
+True
 ```
 Since mostly song and artist are used in conjunction, there is a `current()` method as well.
 ```pydocstring
 >>> spotify.current()
 ('Hello', 'Adele')
 ```
+or you can pass `return_status=True` to also get whether it's playing or not.
+```pydocstring
+>>> spotify.current(return_status=True)
+('Hello', 'Adele', True)
+```
 This allows you to access song and artist by tuple unpacking as:
 ```pydocstring
 >>> song, artist = spotify.current()
+>>> song, artist, is_playing = spotify.current(return_status=True)
 ```
 
 If Spotify is not running or is paused, a `SpotifyNotRunning` Exception is raised.

--- a/SwSpotify/__init__.py
+++ b/SwSpotify/__init__.py
@@ -8,9 +8,10 @@ class SpotifyNotRunning(Exception):
         Attributes:
             expression -- input expression in which the error occurred
             message -- explanation of the error
-        """
+    """
 
-    def __init__(self, message="Spotify appears to be paused or closed at the moment."):
+    def __init__(self, message="Spotify appears to be paused or closed"
+                 " at the moment."):
         super().__init__(message)
 
 

--- a/SwSpotify/__init__.py
+++ b/SwSpotify/__init__.py
@@ -3,11 +3,12 @@ __version__ = '1.0.0'
 
 
 class SpotifyNotRunning(Exception):
-    """Base exception raised if Spotify is not running i.e. is closed or paused.
+    """
+    Base exception raised if Spotify is not running i.e. is closed or paused.
 
-        Attributes:
-            expression -- input expression in which the error occurred
-            message -- explanation of the error
+    Attributes:
+        expression -- input expression in which the error occurred
+        message -- explanation of the error
     """
 
     def __init__(self, message="Spotify appears to be paused or closed"

--- a/SwSpotify/__init__.py
+++ b/SwSpotify/__init__.py
@@ -11,8 +11,7 @@ class SpotifyNotRunning(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, message="Spotify appears to be paused or closed"
-                 " at the moment."):
+    def __init__(self, message="Spotify appears to be paused or closed at the moment."):
         super().__init__(message)
 
 

--- a/SwSpotify/__main__.py
+++ b/SwSpotify/__main__.py
@@ -1,0 +1,13 @@
+from . import spotify
+
+
+def main():
+    title, artist, is_playing = spotify.current(return_status=True)
+    if is_playing:
+        print(f"{title} - {artist}")
+    else:
+        print("Spotify is paused")
+
+
+if __name__ == '__main__':
+    main()

--- a/SwSpotify/__main__.py
+++ b/SwSpotify/__main__.py
@@ -1,4 +1,4 @@
-from . import spotify, SpotifyPaused, SpotifyClosed
+from . import spotify, SpotifyNotRunning
 
 
 def main():

--- a/SwSpotify/__main__.py
+++ b/SwSpotify/__main__.py
@@ -1,12 +1,13 @@
-from . import spotify
+from . import spotify, SpotifyPaused, SpotifyClosed
 
 
 def main():
-    title, artist, is_playing = spotify.current(return_status=True)
-    if is_playing:
-        print(f"{title} - {artist}")
+    try:
+        title, artist = spotify.current()
+    except SpotifyNotRunning as e:
+        print(e)
     else:
-        print("Spotify is paused")
+        print(f"{title} - {artist}")
 
 
 if __name__ == '__main__':

--- a/SwSpotify/__main__.py
+++ b/SwSpotify/__main__.py
@@ -1,4 +1,4 @@
-from . import spotify, SpotifyNotRunning
+from SwSpotify import spotify, SpotifyNotRunning
 
 
 def main():

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -47,7 +47,7 @@ def get_info_windows():
     return track, artist
 
 
-def get_info_linux(return_status=False):
+def get_info_linux():
     """
     Uses the dbus API to get the data.
     """
@@ -104,7 +104,7 @@ def get_info_mac():
     return a[3], a[1]
 
 
-def current(return_status=False):
+def current():
     if sys.platform.startswith("win"):
         return get_info_windows()
     elif sys.platform.startswith("darwin"):

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -27,7 +27,7 @@ def get_info_windows(return_status = False):
         artist = ''
         track = windows[0]
 
-    if spotify[0] in ('Spotify Premium', 'Spotify Free'):
+    if windows[0] in ('Spotify Premium', 'Spotify Free'):
         is_playing = False
         artist = ''
         track = ''
@@ -89,13 +89,13 @@ def get_info_mac(return_status = False):
         return a[3], a[1]
 
 
-def current():
+def current(return_status = False):
     if platform.system() == "Windows":
-        return get_info_windows()
+        return get_info_windows(return_status)
     elif platform.system() == "Darwin":
-        return get_info_mac()
+        return get_info_mac(return_status)
     else:
-        return get_info_linux()
+        return get_info_linux(return_status)
 
 
 def artist():

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -44,7 +44,10 @@ def get_info_linux(return_status = False):
     import dbus
 
     session_bus = dbus.SessionBus()
-    spotify_bus = session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
+    try:
+        spotify_bus = session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
+    except dbus.exceptions.DBusException:
+        raise SpotifyNotRunning
     spotify_properties = dbus.Interface(spotify_bus, "org.freedesktop.DBus.Properties")
 
 
@@ -87,16 +90,12 @@ def get_info_mac(return_status = False):
 
 
 def current():
-    try:
-        if platform.system() == "Windows":
-            return get_info_windows()
-        elif platform.system() == "Darwin":
-            return get_info_mac()
-        else:
-            return get_info_linux()
-    except Exception:
-        raise SpotifyNotRunning from None
-        # from None used to suppress error context
+    if platform.system() == "Windows":
+        return get_info_windows()
+    elif platform.system() == "Darwin":
+        return get_info_mac()
+    else:
+        return get_info_linux()
 
 
 def artist():

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -66,6 +66,10 @@ def get_info_linux(return_status = False):
 
 
 def get_info_mac(return_status = False):
+    """
+    Exceptions aren't thrown inside get_info_mac because it automatically opens Spotify if it's closed.
+    """
+
     from Foundation import NSAppleScript
 
     apple_script_code = """
@@ -76,7 +80,7 @@ def get_info_mac(return_status = False):
             set isPlaying to player state as string
             set currentArtist to artist of current track as string
             set currentTrack to name of current track as string
-            return {currentArtist, currentTrack}
+            return {currentArtist, currentTrack, isPlaying}
         end tell
     end getCurrentlyPlayingTrack
     """

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -1,5 +1,5 @@
 import sys
-from . import SpotifyClosed, SpotifyPaused
+from SwSpotify import SpotifyClosed, SpotifyPaused
 
 
 def get_info_windows():
@@ -56,20 +56,16 @@ def get_info_linux(return_status=False):
 
     session_bus = dbus.SessionBus()
     try:
-        spotify_bus = session_bus.get_object("org.mpris.MediaPlayer2.spotify",
-                                             "/org/mpris/MediaPlayer2")
+        spotify_bus = session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
     except dbus.exceptions.DBusException:
         raise SpotifyClosed
 
-    spotify_properties = dbus.Interface(spotify_bus,
-                                        "org.freedesktop.DBus.Properties")
+    spotify_properties = dbus.Interface(spotify_bus, "org.freedesktop.DBus.Properties")
 
-    metadata = spotify_properties.Get("org.mpris.MediaPlayer2.Player",
-                                      "Metadata")
+    metadata = spotify_properties.Get("org.mpris.MediaPlayer2.Player", "Metadata")
     track = str(metadata['xesam:title'])
     artist = str(metadata['xesam:artist'][0])
-    status = str(spotify_properties.Get("org.mpris.MediaPlayer2.Player",
-                                        "PlaybackStatus"))
+    status = str(spotify_properties.Get("org.mpris.MediaPlayer2.Player", "PlaybackStatus"))
     if status.lower() != 'playing':
         raise SpotifyPaused
 

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -1,4 +1,4 @@
-import platform
+import sys
 from SwSpotify import SpotifyNotRunning
 
 
@@ -20,6 +20,10 @@ def get_info_windows(return_status = False):
         windows.append(old)
     else:
         win32gui.EnumWindows(find_spotify_uwp, windows)
+
+    # If Spotify isn't running the list will be empty
+    if len(windows) == 0:
+        raise SpotifyNotRunning
 
     try:
         artist, track = windows[0].split(" - ", 1)
@@ -49,7 +53,6 @@ def get_info_linux(return_status = False):
     except dbus.exceptions.DBusException:
         raise SpotifyNotRunning
     spotify_properties = dbus.Interface(spotify_bus, "org.freedesktop.DBus.Properties")
-
 
     metadata = spotify_properties.Get("org.mpris.MediaPlayer2.Player", "Metadata")
     track = str(metadata['xesam:title'])
@@ -90,9 +93,9 @@ def get_info_mac(return_status = False):
 
 
 def current(return_status = False):
-    if platform.system() == "Windows":
+    if sys.platform.startswith("win"):
         return get_info_windows(return_status)
-    elif platform.system() == "Darwin":
+    elif sys.platform.startswith("darwin"):
         return get_info_mac(return_status)
     else:
         return get_info_linux(return_status)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setuptools.setup(
     packages=['SwSpotify'],
     install_requires=['pywin32; platform_system=="Windows"',
                       'pyobjc; platform_system=="Darwin"'],
+    extras_require={
+        'dev': ['mock']
+    },
     keywords='spotify swaglyrics python app',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ setuptools.setup(
     install_requires=['pywin32; platform_system=="Windows"',
                       'pyobjc; platform_system=="Darwin"'],
     extras_require={
-        'dev': ['mock']
+        'dev': [
+            'mock',
+            'pytest',
+            'pytest-cov'
+        ]
     },
     keywords='spotify swaglyrics python app',
     classifiers=[


### PR DESCRIPTION
WIP of #3. I need feedback from you to know your thoughts on a couple things:

* As you can see, in the windows version at line 30, I added support for local songs. But what if the song's metadata doesn't have an artist? I fixed this in my own module with [this function](https://github.com/marioortizmanero/spotify-music-videos/blob/master/spotify_videos/utils.py#L13), which tries to split the title into two manually with a regex. Do you want me to copy it over here to use it too?

* What do you think of how I implemented `return_status`?

I'm also improving how errors are thrown rather than just a try/except for everything, and improving how platforms are detected. I added  a `__main__` file so that it can be run with `python -m SwSpotify` to test how it works. I formatted it and added documentation.

The tests have to be checked because it's not passing them.