### PR TITLE
Add support for Spotify Web Player

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,10 @@ install:
 - pip3 install .[dev]
 script:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pytest --cov-config=.coveragerc --cov=SwSpotify
-  tests/test_spotify.py::LinuxTests; pytest --cov-config=.coveragerc --cov=SwSpotify
-    tests/test_spotify.py::WebTests; fi
+  tests/test_spotify.py::LinuxTests; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pytest --cov-config=.coveragerc --cov=SwSpotify
-  tests/test_spotify.py::DarwinTests;  pytest --cov-config=.coveragerc --cov=SwSpotify
-    tests/test_spotify.py::WebTests; fi
+  tests/test_spotify.py::DarwinTests; fi
+- pytest --cov-config=.coveragerc --cov=SwSpotify tests/test_spotify.py::WebTests; 
 after_success:
 - bash <(curl -s https://codecov.io/bash) -Z
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ install:
 - pip3 install .[dev]
 script:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pytest --cov-config=.coveragerc --cov=SwSpotify
-  tests/test_spotify.py::LinuxTests; fi
+  tests/test_spotify.py::LinuxTests; pytest --cov-config=.coveragerc --cov=SwSpotify
+    tests/test_spotify.py::WebTests; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pytest --cov-config=.coveragerc --cov=SwSpotify
-  tests/test_spotify.py::DarwinTests; fi
+  tests/test_spotify.py::DarwinTests;  pytest --cov-config=.coveragerc --cov=SwSpotify
+    tests/test_spotify.py::WebTests; fi
 after_success:
 - bash <(curl -s https://codecov.io/bash) -Z
 deploy:

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -58,9 +58,9 @@ def get_info_linux():
 
     import dbus
 
-    if not hasattr(get_info_linux, 'session_bus'):
-        get_info_linux.session_bus = dbus.SessionBus()
     try:
+        if not hasattr(get_info_linux, 'session_bus'):
+            get_info_linux.session_bus = dbus.SessionBus()
         spotify_bus = get_info_linux.session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
         spotify_properties = dbus.Interface(spotify_bus, "org.freedesktop.DBus.Properties")
         metadata = spotify_properties.Get("org.mpris.MediaPlayer2.Player", "Metadata")

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -143,7 +143,10 @@ def get_info_web(timeout=0.1):
                         pass
 
             if result:
-                return result["name"], result["artist"]
+                if result["isPlaying"]:
+                    return result["name"], result["artist"]
+                else:
+                    raise SpotifyPaused
     else:
         raise SpotifyClosed
 

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -124,7 +124,7 @@ def get_info_web(timeout=0.1):
     with open(get_data, "w", encoding="utf-8") as f:
         f.write("get_data")
 
-    # If the file for retrieving data doesn't exists, create and leave it blank
+    # If the file for retrieving data doesn't exist, create and leave it blank
     if not os.path.exists(last_played):
         with open(last_played, 'w', encoding="utf-8"):
             pass
@@ -146,6 +146,7 @@ def get_info_web(timeout=0.1):
                 return result["name"], result["artist"]
     else:
         raise SpotifyClosed
+
 
 def current():
     # First try native approaches, then try using the web approach

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -116,7 +116,7 @@ def get_info_mac():
     return a[3], a[1]
 
 
-def get_info_web():
+def get_info_web(timeout=0.1):
     # Paths for the files used for commucation with the Chrome extension
     get_data = os.path.join(tempfile.gettempdir(), "get_data")
     last_played = os.path.join(tempfile.gettempdir(), "last_played")
@@ -132,7 +132,7 @@ def get_info_web():
     # Wait till the last_played data changes and return its value, 0.1 seconds for timeout
     last_changed = os.path.getmtime(last_played)
     t = time.time()
-    while time.time() - t < 0.1:
+    while time.time() - t < timeout:
         if os.path.getmtime(last_played) != last_changed:
             while True:
                 with open(last_played, "r", encoding="utf-8") as f:

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -115,17 +115,19 @@ def get_info_mac():
 
     return a[3], a[1]
 
+
 def get_info_web():
     # Paths for the files used for commucation with the Chrome extension
     get_data = os.path.join(tempfile.gettempdir(), "get_data")
     last_played = os.path.join(tempfile.gettempdir(), "last_played")
     # Update file to trigger the Chrome extension for retrieving data
-    with open(get_data, "w") as f:
+    with open(get_data, "w", encoding="utf-8") as f:
         f.write("get_data")
 
     # If the file for retrieving data doesn't exists, create and leave it blank
     if not os.path.exists(last_played):
-        with open(last_played, 'w'): pass
+        with open(last_played, 'w', encoding="utf-8"):
+            pass
 
     # Wait till the last_played data changes and return its value, 0.1 seconds for timeout
     last_changed = os.path.getmtime(last_played)
@@ -133,7 +135,7 @@ def get_info_web():
     while time.time() - t < 0.1:
         if os.path.getmtime(last_played) != last_changed:
             while True:
-                with open(last_played, "r") as f:
+                with open(last_played, "r", encoding="utf-8") as f:
                     try:
                         result = json.loads(f.read())
                         break
@@ -154,7 +156,7 @@ def current():
             return get_info_mac()
         else:
             return get_info_linux()
-    except (SpotifyClosed, SpotifyPaused):
+    except SpotifyNotRunning:
         return get_info_web()
 
 

--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -127,15 +127,21 @@ def get_info_web():
     if not os.path.exists(last_played):
         with open(last_played, 'w'): pass
 
-    # Wait till the last_played data changes and return its value, 0.5 seconds for timeout
+    # Wait till the last_played data changes and return its value, 0.1 seconds for timeout
     last_changed = os.path.getmtime(last_played)
     t = time.time()
-    while time.time() - t < 0.5:
+    while time.time() - t < 0.1:
         if os.path.getmtime(last_played) != last_changed:
-            with open(last_played, "r") as f:
-                result = json.loads(f.read())
-                if result:
-                    return result["name"], result["artist"]
+            while True:
+                with open(last_played, "r") as f:
+                    try:
+                        result = json.loads(f.read())
+                        break
+                    except json.JSONDecodeError:
+                        pass
+
+            if result:
+                return result["name"], result["artist"]
     else:
         raise SpotifyClosed
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ test_script:
   # to put the Python version you want to use on PATH.
   #- "%PYTHON%\\python.exe -m nosetests --nocapture --with-cov --cov-config .coveragerc"
   - "%PYTHON%/Scripts/pytest --cov-config=.coveragerc --cov=SwSpotify tests/test_spotify.py::WindowsTests"
+  - "%PYTHON%/Scripts/pytest --cov-config=.coveragerc --cov=SwSpotify tests/test_spotify.py::WebTests"
 
 after_test:
   # This step builds your wheels.

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -245,7 +245,7 @@ class WebTests(unittest.TestCase):
         """
         test that test get_info_web function works with the files created
         """
-        self.assertTrue(get_info_web() == ("Suspus", "Ceza"))
+        self.assertEqual(get_info_web(), ("Suspus", "Ceza"))
 
 
 if __name__ == '__main__':

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -2,6 +2,7 @@
 Contains unit tests for spotify.py
 """
 import os
+import tempfile
 import unittest
 from SwSpotify.spotify import song, artist, get_info_windows, get_info_web
 from SwSpotify import SpotifyNotRunning, SpotifyPaused

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -242,26 +242,13 @@ class WebTests(unittest.TestCase):
 
         self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
-    @patch("os.path.getmtime")
-    @patch("json.loads")
+    @patch("os.path.getmtime", return_value=float('nan'))
+    @patch("json.loads", return_value={"artist":"Ceza", "name":"Suspus"})
     def test_that_get_info_web_works(self, gettime, jsonload):
         """
         test that test get_info_web function works with the files created
         """
-        def test_web():
-            try:
-                return get_info_web()
-            except SpotifyNotRunning:
-                pass
-
-        que = queue.Queue()
-        t = threading.Thread(target=lambda q: q.put(test_web()), args=(que))
-        t.start()
-        t.join()
-        time.sleep(0.03)
-        gettime.return_value = float("inf")
-        jsonload.return_value = {"artist":"Ceza", "name":"Suspus"}
-        self.assertTrue(que.get()==["Suspus", "Ceza"])
+        self.assertTrue(get_info_web()==("Suspus", "Ceza"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -4,9 +4,6 @@ Contains unit tests for spotify.py
 import os
 import tempfile
 import unittest
-import threading
-import time
-import queue
 from SwSpotify.spotify import song, artist, get_info_windows, get_info_web
 from SwSpotify import SpotifyNotRunning, SpotifyPaused
 from mock import patch
@@ -242,13 +239,6 @@ class WebTests(unittest.TestCase):
 
         self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
-    @patch("os.path.getmtime", return_value=float('nan'))
-    @patch("json.loads", return_value={"artist":"Ceza", "name":"Suspus"})
-    def test_that_get_info_web_works(self, gettime, jsonload):
-        """
-        test that test get_info_web function works with the files created
-        """
-        self.assertTrue(get_info_web()==("Suspus", "Ceza"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -200,7 +200,7 @@ class WebTests(unittest.TestCase):
         """
         test that test artist function calls get_info_web function
         """
-        x = artist()
+        artist()
         self.assertTrue(mock.called)
 
     @patch('SwSpotify.spotify.get_info_web')
@@ -208,7 +208,7 @@ class WebTests(unittest.TestCase):
         """
         test that test song function calls get_info_web function
         """
-        x = song()
+        song()
         self.assertTrue(mock.called)
 
     def test_that_artist_function_returns_None_when_error(self):
@@ -240,12 +240,12 @@ class WebTests(unittest.TestCase):
         self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
     @patch("os.path.getmtime", return_value=float('nan'))
-    @patch("json.loads", return_value={"artist":"Ceza", "name":"Suspus"})
+    @patch("json.loads", return_value={"artist": "Ceza", "name": "Suspus"})
     def test_that_get_info_web_works(self, gettime, jsonload):
         """
         test that test get_info_web function works with the files created
         """
-        self.assertTrue(get_info_web()==("Suspus", "Ceza"))
+        self.assertTrue(get_info_web() == ("Suspus", "Ceza"))
 
 
 if __name__ == '__main__':

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,6 +1,7 @@
 """
 Contains unit tests for spotify.py
 """
+import os
 import unittest
 from SwSpotify.spotify import song, artist, get_info_windows
 from SwSpotify import SpotifyNotRunning, SpotifyPaused
@@ -222,6 +223,20 @@ class WebTests(unittest.TestCase):
         """
         x = song
         self.assertRaises(SpotifyNotRunning, x)
+
+    def test_that_get_info_web_creates_tempfiles(self):
+        """
+        test that test get_info_web function creates tempfiles for communication
+        """
+        try:
+            get_info_web()
+        except SpotifyNotRunning:
+            pass
+
+        get_data = os.path.join(tempfile.gettempdir(), "get_data")
+        last_played = os.path.join(tempfile.gettempdir(), "last_played")
+
+        self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
 
 if __name__ == '__main__':

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -254,14 +254,14 @@ class WebTests(unittest.TestCase):
             except SpotifyNotRunning:
                 pass
 
-        q = queue.Queue()
-        t = Thread(target=lambda q: q.put(test_web()), args=(que))
+        que = queue.Queue()
+        t = threading.Thread(target=lambda q: q.put(test_web()), args=(que))
         t.start()
         t.join()
         time.sleep(0.03)
         gettime.return_value = float("inf")
         jsonload.return_value = {"artist":"Ceza", "name":"Suspus"}
-        self.assertTrue(q.get()==["Suspus", "Ceza"])
+        self.assertTrue(que.get()==["Suspus", "Ceza"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -3,7 +3,7 @@ Contains unit tests for spotify.py
 """
 import os
 import unittest
-from SwSpotify.spotify import song, artist, get_info_windows
+from SwSpotify.spotify import song, artist, get_info_windows, get_info_web
 from SwSpotify import SpotifyNotRunning, SpotifyPaused
 from mock import patch
 import platform

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -239,6 +239,14 @@ class WebTests(unittest.TestCase):
 
         self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
+    @patch("os.path.getmtime", return_value=float('nan'))
+    @patch("json.loads", return_value={"artist":"Ceza", "name":"Suspus"})
+    def test_that_get_info_web_works(self, gettime, jsonload):
+        """
+        test that test get_info_web function works with the files created
+        """
+        self.assertTrue(get_info_web()==("Suspus", "Ceza"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -240,12 +240,20 @@ class WebTests(unittest.TestCase):
         self.assertTrue(os.path.exists(last_played) and os.path.exists(get_data))
 
     @patch("os.path.getmtime", return_value=float('nan'))
-    @patch("json.loads", return_value={"artist": "Ceza", "name": "Suspus"})
+    @patch("json.loads", return_value={"artist": "Ceza", "name": "Suspus", "isPlaying": True})
     def test_that_get_info_web_works(self, gettime, jsonload):
         """
         test that test get_info_web function works with the files created
         """
         self.assertEqual(get_info_web(), ("Suspus", "Ceza"))
+
+    @patch("os.path.getmtime", return_value=float('nan'))
+    @patch("json.loads", return_value={"artist": "Ceza", "name": "Suspus", "isPlaying": False})
+    def test_that_get_info_web_raises_exception_when_spotify_paused(self, gettime, jsonload):
+        """
+        test that test get_info_web raises exception when Spotify is paused
+        """
+        self.assertRaises(SpotifyPaused, get_info_web)
 
 
 if __name__ == '__main__':

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -185,5 +185,44 @@ class DarwinTests(unittest.TestCase):
         self.assertRaises(SpotifyNotRunning, x)
 
 
+class WebTests(unittest.TestCase):
+    """
+    Unit tests for web player
+    """
+
+    def setup(self):
+        pass
+
+    @patch('SwSpotify.spotify.get_info_web')
+    def test_that_artist_function_calls_get_info(self, mock):
+        """
+        test that test artist function calls get_info_web function
+        """
+        x = artist()
+        self.assertTrue(mock.called)
+
+    @patch('SwSpotify.spotify.get_info_web')
+    def test_that_song_function_calls_get_info(self, mock):
+        """
+        test that test song function calls get_info_web function
+        """
+        x = song()
+        self.assertTrue(mock.called)
+
+    def test_that_artist_function_returns_None_when_error(self):
+        """
+        test that test artist function returns None when the get_info_web function will return an error
+        """
+        x = artist
+        self.assertRaises(SpotifyNotRunning, x)
+
+    def test_that_song_function_returns_None_when_error(self):
+        """
+        test that test song function returns None when the get_info_web function will return an error
+        """
+        x = song
+        self.assertRaises(SpotifyNotRunning, x)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi!

Here is my approach:

I've created a little Python script called bridge.py that enables [SwagLyrics-Chrome-Extension](https://github.com/SwagLyrics/SwagLyrics-Chrome-Extension) to communicate with SwSpotify. When SwSpotify tries the native approaches and fails to return a value, it then tries to communicate with the Chrome extension.

Related pull request: https://github.com/SwagLyrics/SwagLyrics-Chrome-Extension/pull/1