### PR TITLE
Function lower wasn't called instead Referenced

### DIFF
--- a/SwSpotify/spotify.py
+++ b/SwSpotify/spotify.py
@@ -103,7 +103,7 @@ def get_info_mac():
         s = NSAppleScript.alloc().initWithSource_(apple_script_code)
         x = s.executeAndReturnError_(None)
         a = str(x[0]).split('"')
-        if a[5].lower != 'playing':
+        if a[5].lower() != 'playing':
             raise SpotifyPaused
     except IndexError:
         raise SpotifyClosed from None


### PR DESCRIPTION
Calling `print(a[5])` gives either `playing` or `paused`
Calling `print(a[5]).lower` gives something like this `<built-in method lower of str object at 0x10b8852b0>` which is a bit wrong. Shouldn't it give a string and not a bult-in method?

and that happens usually because `()` are forgotten. The lower function was never called and hence always triggered the SpotifyPaused exception

This simple 2 characther fix is solving the issue
