### PR TITLE
use subprocess instead of pyobjc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ SwSpotify\.egg-info/
 tests/__pycache__/
 
 \.coverage
+
+env/

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,15 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SwagLyrics/SwSpotify",
-    packages=['SwSpotify'],
-    install_requires=['flask==2.0.1', 'requests>=2.24.0', 'flask-cors==3.0.10', 'pywin32; platform_system=="Windows"',
-                      'pyobjc; platform_system=="Darwin"'],
-    extras_require={
-        'dev': [
-            'mock',
-            'pytest',
-            'pytest-cov'
-        ]
-    },
-    keywords='spotify swaglyrics python app',
+    packages=["SwSpotify"],
+    install_requires=[
+        "flask==2.0.1",
+        "requests>=2.24.0",
+        "flask-cors==3.0.10",
+        'pywin32; platform_system=="Windows"',
+    ],
+    extras_require={"dev": ["mock", "pytest", "pytest-cov"]},
+    keywords="spotify swaglyrics python app",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
gets rid of a HUGE dependency

I also refactored the error handling as when script runs and spotify is closed then it returns with a status code of 0 but stdout is empty so we can use that to throw `SpotifyPaused`.

Let me know your thoughts and we can merge

Also used black to format the file.

just updated ci on master to use newer python versions too